### PR TITLE
[WIP] Fixed first InteractiveInstaller error

### DIFF
--- a/lib/Multisites/Controller/InteractiveInstaller.php
+++ b/lib/Multisites/Controller/InteractiveInstaller.php
@@ -12,7 +12,7 @@
  * information regarding copyright and licensing.
  */
 
-class Multisites_Controller_Interactiveinstaller extends Zikula_Controller_AbstractInteractiveInstaller
+class Multisites_Controller_InteractiveInstaller extends Zikula_Controller_AbstractInteractiveInstaller
 {
     /**
      * Initialise the interactive install system for the Multisites module


### PR DESCRIPTION
Class names were wrong: `Interactiveinstaller` => `InteractiveInstaller`

**TODO**
- [ ] step1() is never reached, see https://github.com/zikula/core/issues/718
